### PR TITLE
Improved font loading strategy.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "shopmakers",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -46,6 +46,13 @@ const Container: React.FC<ContainerProps> = ({ children, seo = {} }) => {
           content="width=device-width, initial-scale=1, shrink-to-fit=no"
         />
         <meta name="HandheldFriendly" content="true" />
+        <link
+          rel="preload"
+          href="/fonts/jost.woff2"
+          as="font"
+          type="font/woff2"
+          crossOrigin
+        />
         <link rel="canonical" href={`https://shopmakers.tech${canonical}`} />
         {isArticle && typeof meta.alternate === 'object'
           ? Object.entries(meta.alternate)?.map(([locale, slug]) => {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,20 +2,22 @@
 @tailwind components;
 @tailwind utilities;
 
-@supports (font-variation-settings: normal) {
-  @font-face {
-    font-family: 'Jost';
-    font-style: normal;
-    font-weight: 200 600;
-    font-display: swap;
-    src: url('/fonts/jost.woff2') format('woff2');
+@layer base {
+  @supports (font-variation-settings: normal) {
+    @font-face {
+      font-family: 'Jost';
+      font-style: normal;
+      font-weight: 200 600;
+      font-display: swap;
+      src: url('/fonts/jost.woff2') format('woff2');
+    }
   }
-}
 
-html {
-  @apply text-prussian-blue;
-}
+  html {
+    @apply text-prussian-blue;
+  }
 
-.link {
-  @apply text-blue-green rounded hover:underline focus:outline-none focus:ring-2
+  p a {
+    @apply text-blue-green rounded hover:underline focus:outline-none focus:ring-2
+  }
 }


### PR DESCRIPTION
- Font loading (and setting of `color` on `<html>` was appended to the end of the stylesheet
- Use Tailwind's `@layer` to put it into the Preflight styling at the top of generated stylesheet meaning fonts are loaded sooner
- Add `<link rel="preload">` tag to `<head>` to force browser to fetch font files before they are downloaded via CSS
- Ensure all content-based links (anything inside a paragraph) get the same styling and don't rely on a class